### PR TITLE
Fix the copy button on mobile: first-tap copy and line wrapping

### DIFF
--- a/scripts/build-markdown.ts
+++ b/scripts/build-markdown.ts
@@ -189,13 +189,15 @@ type WritingPost = {
 // to a reader who already has the markdown in hand, so it leaves no trace in the twin.
 // These sit inline in a sentence, so they are cut out of the line rather than dropping it.
 const CHROME_COMPONENTS = ["CopyAsMarkdown"];
-// The separator in front is taken with it. It is a non-breaking space in the source — that is
-// what keeps the button on the same line as the sentence it belongs to — and left behind it
-// would surface in the twin as a literal `&nbsp;`.
+// The separator in front is taken with it, so the sentence does not end on a dangling space.
 const CHROME_PATTERN = new RegExp(
   `(?:&nbsp;|&#160;|\\s)*<(?:${CHROME_COMPONENTS.join("|")})\\b[^>]*/>`,
   "g",
 );
+
+// A span is layout, never content — the article uses one to hold a word and the copy button on
+// the same line. Only its tags go; whatever it wraps is prose that belongs in the twin.
+const LAYOUT_SPAN_PATTERN = /<\/?span\b[^>]*>/g;
 
 const INTERACTIVE_NOTE = "*(Interactive content on the web page.)*";
 
@@ -277,7 +279,12 @@ function cleanMdxBody(body: string, postDir: string): string {
     // Spacing between sections on the page; in markdown the blank lines already say it.
     if (/^\s*<br\s*\/?>\s*$/.test(line)) continue;
 
-    const stripped = line.replace(CHROME_PATTERN, "");
+    let stripped = line.replace(CHROME_PATTERN, "");
+    if (stripped.includes("<span")) {
+      // Unwrapping the span leaves the emphasis it splits showing as two runs (`_a_ _b_`).
+      // Rejoining them keeps the sentence one italic phrase, the way the page renders it.
+      stripped = stripped.replace(LAYOUT_SPAN_PATTERN, "").replace(/_ _/g, " ");
+    }
     const component = stripped.match(/^\s*<([A-Z]\w*)/)?.[1];
     if (!component) {
       // A line that was nothing but furniture disappears; one that merely ended with some

--- a/scripts/build-markdown.ts
+++ b/scripts/build-markdown.ts
@@ -189,7 +189,13 @@ type WritingPost = {
 // to a reader who already has the markdown in hand, so it leaves no trace in the twin.
 // These sit inline in a sentence, so they are cut out of the line rather than dropping it.
 const CHROME_COMPONENTS = ["CopyAsMarkdown"];
-const CHROME_PATTERN = new RegExp(`\\s*<(?:${CHROME_COMPONENTS.join("|")})\\b[^>]*/>`, "g");
+// The separator in front is taken with it. It is a non-breaking space in the source — that is
+// what keeps the button on the same line as the sentence it belongs to — and left behind it
+// would surface in the twin as a literal `&nbsp;`.
+const CHROME_PATTERN = new RegExp(
+  `(?:&nbsp;|&#160;|\\s)*<(?:${CHROME_COMPONENTS.join("|")})\\b[^>]*/>`,
+  "g",
+);
 
 const INTERACTIVE_NOTE = "*(Interactive content on the web page.)*";
 

--- a/src/features/writing/components/copy-as-markdown.tsx
+++ b/src/features/writing/components/copy-as-markdown.tsx
@@ -36,7 +36,7 @@ export function CopyAsMarkdown() {
   const [state, setState] = useState<State>("idle");
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const markdown = useRef<string | null>(null);
-  const pending = useRef<Promise<void> | null>(null);
+  const request = useRef<Promise<string> | null>(null);
 
   const settle = (next: State) => {
     setState(next);
@@ -44,14 +44,8 @@ export function CopyAsMarkdown() {
     resetTimer.current = setTimeout(() => setState("idle"), RESET_DELAY);
   };
 
-  /* Fetched on approach rather than on click, so the round trip happens while the pointer is
-     still travelling and the press itself has nothing to wait for. Started from hover, focus
-     and pointerdown alike: a mouse announces itself well ahead, a finger only at pointerdown,
-     and the keyboard not at all until focus lands. A reader who never goes near the button
-     never pays for the request. */
-  const prefetch = () => {
-    if (markdown.current !== null) return pending.current ?? Promise.resolve();
-    pending.current ??= fetch(`${window.location.pathname.replace(/\/$/, "")}.md`, {
+  const load = () => {
+    request.current ??= fetch(`${window.location.pathname.replace(/\/$/, "")}.md`, {
       headers: { accept: "text/markdown" },
     })
       .then((response) => {
@@ -60,41 +54,67 @@ export function CopyAsMarkdown() {
       })
       .then((text) => {
         markdown.current = text;
+        return text;
       })
-      // Swallowed here because there is nothing to report yet — nobody has asked for anything.
-      // The click retries and is the one that gets to say it failed.
-      .catch(() => {})
-      .finally(() => {
-        pending.current = null;
+      .catch((error: unknown) => {
+        // Never cache a failure: the next press has to be a fresh attempt, not a replay of
+        // this rejection.
+        request.current = null;
+        throw error;
       });
-    return pending.current;
+    return request.current;
   };
 
-  const copy = async () => {
-    // Awaiting the fetch first spends the click's transient activation, and Safari then refuses
-    // the clipboard outright — so the write has to be the first thing the handler does with
-    // text already in hand. The await below only runs when the prefetch has not landed, which
-    // is the first tap on a touch device and nothing else.
-    if (markdown.current === null) await prefetch();
-    if (markdown.current === null) {
-      settle("failed");
+  /* Fetched on approach rather than on click, so the round trip happens while the pointer is
+     still travelling and the press itself has nothing to wait for. Started from hover, focus
+     and pointerdown alike: a mouse announces itself well ahead, a finger only at pointerdown,
+     and the keyboard not at all until focus lands. A reader who never goes near the button
+     never pays for the request. Rejections are swallowed because nobody has asked for
+     anything yet — the press is what gets to report a failure. */
+  const prefetch = () => {
+    void load().catch(() => {});
+  };
+
+  const report = (work: Promise<unknown>) => {
+    work.then(() => settle("copied")).catch(() => settle("failed"));
+  };
+
+  const copy = () => {
+    const ready = markdown.current;
+    if (ready !== null) {
+      report(navigator.clipboard.writeText(ready));
       return;
     }
 
-    try {
-      await navigator.clipboard.writeText(markdown.current);
-      settle("copied");
-    } catch {
-      // Clipboard access is refused outright in some contexts, and there is nothing to retry.
-      // Saying so beats a button that silently does nothing.
-      settle("failed");
+    /* Nothing prefetched yet, which on a touch device is every first tap: pointerdown lands
+       only a moment before the click. Awaiting the fetch here and then writing is what made
+       the button report a failure it had not earned — an await spends the gesture's transient
+       activation, and Safari refuses the clipboard from that point on.
+
+       So the write is handed a *promise* instead. `ClipboardItem` accepts one, which is
+       exactly this case: the write is authorised by the gesture that started it and resolves
+       whenever the text lands. Where that is unsupported there is nothing left but to await
+       and try, which is what the browsers missing it accept anyway. */
+    const pending = load();
+    if (typeof ClipboardItem === "function") {
+      const item = new ClipboardItem({
+        "text/plain": pending.then((text) => new Blob([text], { type: "text/plain" })),
+      });
+      report(
+        navigator.clipboard
+          .write([item])
+          .catch(() => pending.then((text) => navigator.clipboard.writeText(text))),
+      );
+      return;
     }
+
+    report(pending.then((text) => navigator.clipboard.writeText(text)));
   };
 
   return (
     // The label lives in the tooltip rather than beside the icon, on the app's default delay.
     // No `title` alongside it: the browser's own tooltip would arrive late and say it twice.
-    <Tooltip content={LABEL[state]} inline className="not-prose ml-1 align-[-0.3em]">
+    <Tooltip content={LABEL[state]} inline className="not-prose align-[-0.3em]">
       <button
         type="button"
         onClick={copy}

--- a/src/writing/tips-to-improve-your-product/article.mdx
+++ b/src/writing/tips-to-improve-your-product/article.mdx
@@ -16,7 +16,7 @@ import { SwitchStretch } from "./demos/switch-stretch";
 
 This article bullet-point-lists a bunch of tips I personally found helpful when I learned them. Most of these come from practical work, where we encountered edge cases. I believe continuous refactoring of the elements used in your app, even when you use an existing design system, leads to a better user experience in the long run.
 
-_Obviously, feel free to copy this article and give it your agent._&nbsp;<CopyAsMarkdown />
+_Obviously, feel free to copy this article and give it your_ <span className="whitespace-nowrap">_agent._ <CopyAsMarkdown /></span>
 
 ## Avatar Groups, done right
 

--- a/src/writing/tips-to-improve-your-product/article.mdx
+++ b/src/writing/tips-to-improve-your-product/article.mdx
@@ -16,7 +16,7 @@ import { SwitchStretch } from "./demos/switch-stretch";
 
 This article bullet-point-lists a bunch of tips I personally found helpful when I learned them. Most of these come from practical work, where we encountered edge cases. I believe continuous refactoring of the elements used in your app, even when you use an existing design system, leads to a better user experience in the long run.
 
-_Obviously, feel free to copy this article and give it your agent._ <CopyAsMarkdown />
+_Obviously, feel free to copy this article and give it your agent._&nbsp;<CopyAsMarkdown />
 
 ## Avatar Groups, done right
 


### PR DESCRIPTION
Two mobile bugs in the copy button, both visible in the same screenshot.

> Stacked on `claude/agent-usable-tips-article` (#43), since the button only exists there. Merge that one first and this retargets to `main` automatically.

## The × was a real failure, not a display glitch

On touch there is no hover to prefetch from — `pointerdown` lands only a moment before the click — so the press fell through to the path that awaited the fetch and *then* wrote to the clipboard. That await spends the gesture's transient activation, and Safari refuses the clipboard from that point on. So the very first tap on a phone reported a failure it had not earned, and only the second tap worked, because by then the prefetch had landed.

The write is now handed a **promise** rather than a string. `ClipboardItem` accepts one, which is precisely this case: the write is authorised by the gesture that started it and resolves whenever the text arrives. Where `ClipboardItem` is unavailable it falls back to awaiting and writing, which those browsers accept anyway.

A failed fetch also stops being cached — the previous version stored the rejected promise, so every later press replayed the same failure instead of retrying.

## The button orphaned onto its own line

The sentence stayed above and the icon dropped below it, reading as a stray glyph under the paragraph. The space before the button is now non-breaking, so the last words travel with it — a break opportunity removed rather than a width guessed at.

The markdown pass takes that separator along with the component; left behind, it would surface in the twin as a literal `&nbsp;`. Verified the twin still reads `_Obviously, feel free to copy this article and give it your agent._` with nothing trailing it.

## Verification

`typecheck`, `lint`, `format`, `build`, 45 tests. I also checked the compiled MDX chunk to confirm the NBSP survives compilation as a text node between the `<em>` and the button, rather than assuming the entity made it through.

Not verified by me: the actual clipboard behaviour on a real iOS device — this environment can't reach the preview, so the first-tap path is worth a check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaDvRvdzbf4afb1aFYVr1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaDvRvdzbf4afb1aFYVr1n)_